### PR TITLE
Services pages

### DIFF
--- a/src/components/widgets/Hero_Services.tsx
+++ b/src/components/widgets/Hero_Services.tsx
@@ -1,8 +1,7 @@
 import { component$ } from "@builder.io/qwik";
 import { Image } from "@unpic/qwik";
 
-const coverImage =
-  "https://images.unsplash.com/photo-1590767950092-42b8362368da?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3087&q=80";
+const coverImage = "../public/images/Dave_headshot_Simplifya_1500x1500.jpeg";
 
 export default component$(() => {
   return (
@@ -11,6 +10,18 @@ export default component$(() => {
       <div class="relative max-w-7xl mx-auto px-4 sm:px-6">
         <div class="pt-0 md:pt-[76px] pointer-events-none"></div>
         <div class="py-12 md:py-20 lg:py-0 lg:flex lg:items-center lg:h-screen lg:gap-8">
+          <div class="basis-1/2">
+              <Image
+                src={coverImage}
+                layout="constrained"
+                width={493}
+                height={616}
+                alt="Qwind Hero Image (Cool dog)"
+                class="mx-auto lg:mr-0 w-full drop-shadow-2xl rounded-md"
+                priority={true}
+                breakpoints={[320, 480, 640, 768, 1024]}
+              />
+            </div>
           <div class="basis-1/2 text-center lg:text-left pb-10 md:pb-16 mx-auto">
             <h1 class="text-5xl md:text-6xl font-bold leading-tighter tracking-tighter mb-4 font-heading dark:text-gray-200">
               Free template for <br class="hidden lg:block" />{" "}
@@ -46,18 +57,6 @@ export default component$(() => {
                 </div>
               </div>
             </div>
-          </div>
-          <div class="basis-1/2">
-            <Image
-              src={coverImage}
-              layout="constrained"
-              width={493}
-              height={616}
-              alt="AI Artistry Home Page Hero Image"
-              class="mx-auto lg:mr-0 w-full drop-shadow-2xl rounded-md"
-              priority={true}
-              breakpoints={[320, 480, 640, 768, 1024]}
-            />
           </div>
         </div>
       </div>

--- a/src/components/widgets/Stats.tsx
+++ b/src/components/widgets/Stats.tsx
@@ -6,34 +6,49 @@ export default component$(() => {
       <div class="grid grid-cols-2 row-gap-8 md:grid-cols-4">
         <div class="text-center md:border-r dark:md:border-slate-500 mb-10 md:mb-0">
           <div class="text-4xl font-bold lg:text-5xl xl:text-6xl text-[#039de1] font-heading">
-            132K
+            64%
           </div>
           <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
-            Downloads
+            of workers unfamiliar 
+          </p>
+          <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
+            with AI tools
           </p>
         </div>
         <div class="text-center md:border-r dark:md:border-slate-500 mb-10 md:mb-0">
           <div class="text-4xl font-bold lg:text-5xl xl:text-6xl text-[#039de1] font-heading">
-            24.8K
+            31%
           </div>
           <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
-            Stars
+            of companies have a
+          </p>
+          <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
+            formal AI strategy
           </p>
         </div>
         <div class="text-center md:border-r dark:md:border-slate-500 font-heading">
           <div class="text-4xl font-bold lg:text-5xl xl:text-6xl text-[#039de1]">
-            10.3K
+            41%
           </div>
           <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
-            Forks
+            of organizations don’t
+          </p>
+          <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
+            collect employee feedback
+          </p>
+          <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
+            on AI tools
           </p>
         </div>
         <div class="text-center">
           <div class="text-4xl font-bold lg:text-5xl xl:text-6xl text-[#039de1] font-heading">
-            48.4K
+            56%
           </div>
           <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
-            Users
+            of workers are proactively
+          </p>
+          <p class="text-sm font-medium tracking-widest text-gray-800 dark:text-slate-400 uppercase lg:text-base">
+            learning about gen AI
           </p>
         </div>
       </div>

--- a/src/components/widgets/Steps.tsx
+++ b/src/components/widgets/Steps.tsx
@@ -7,24 +7,24 @@ const sideImg =
 
 export default component$(() => {
   const stepsData = {
-    title: "Sed ac magna sit amet risus tristique interdum. hac.",
+    title: "Half and full-day workshops tailored to your needs.",
     items: [
       {
-        title: "Step 1",
+        title: "AI Readiness Assessment",
         description:
-          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mirisus tempus nulla, sed porttitor est nibh at nulla. Praesent placerat enim ut ex tincidunt vehicula. Fusce sit amet dui tellus.",
+          "Understand your current level of AI adoption, specific goals for AI implementation, and identify challenges or concerns.",
         icon: IconStar,
       },
       {
-        title: "Step 2",
+        title: "Targeted AI Workshops",
         description:
-          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mirisus tempus nulla, sed porttitor est nibh at nulla.",
+          "Develop a customized programs designed to meet your teams' unique challenges and goals.",
         icon: IconStar,
       },
       {
-        title: "Step 3",
+        title: "Future Proofing",
         description:
-          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mirisus tempus nulla, sed porttitor est nibh at nulla.",
+          "Provide content and tools to help and measure the value of future AI initiatives.",
         icon: IconStar,
       },
       {

--- a/src/routes/about/index.tsx
+++ b/src/routes/about/index.tsx
@@ -2,9 +2,6 @@ import { component$ } from '@builder.io/qwik';
 import type { DocumentHead } from "@builder.io/qwik-city";
 
 import Hero from "~/components/widgets/Hero_About";
-import CallToAction from "~/components/widgets/CallToAction";
-
-import { qwikSerialized } from "~/utils/qwikSerialized";
 
 import { SITE } from "~/config.mjs";
 

--- a/src/routes/courses/index.tsx
+++ b/src/routes/courses/index.tsx
@@ -1,7 +1,6 @@
 import { component$ } from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
 
-import Hero from "~/components/widgets/Hero_Services";
 import Features from "~/components/widgets/Features";
 import Steps from "~/components/widgets/Steps";
 import FAQs from "~/components/widgets/FAQs";
@@ -21,7 +20,6 @@ import { SITE } from "~/config.mjs";
 export default component$(() => {
   return (
     <>
-      <Hero />
       <Features
         highlight="Courses"
         title="What our courses cover"

--- a/src/routes/courses/index.tsx
+++ b/src/routes/courses/index.tsx
@@ -23,84 +23,67 @@ export default component$(() => {
       <Features
         highlight="Courses"
         title="What our courses cover"
-        subtitle="Master AI essentials in just one hour! This engaging, hands-on course equips your team with the skills and confidence to harness AI effectively and responsibly in the workplace."
+        subtitle="Courses designed to drive innovation, boost confidence, and ensure AI delivers real business value."
         items={[
           {
-            title: "Qwik + Tailwind CSS Integration",
-            description:
-              "A seamless integration between two great frameworks that offer high productivity, performance and versatility.",
-            icon: IconBrandTailwind,
+            title: "AI Strategy for Business",
+            description: "Equip your business to thrive in the age of AI.",
           },
           {
-            title: "Ready-to-use Components",
-            description:
-              "Widgets made with Tailwind CSS ready to be used in Marketing Websites, SaaS, Blogs, Personal Profiles, Small Business...",
-            icon: IconApps,
+            title: "AI Transformation: A People-First Approach",
+            description: "Empower your people for the future of work.",
           },
           {
-            title: "Best Practices",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            title: "AI Literacy for Leaders", 
+            description: "Drive AI adoption by understanding its capabilities.",
           },
           {
-            title: "Excellent Page Speed",
-            description:
-              "Having a good page speed impacts organic search ranking, improves user experience (UI/UX) and increase conversion rates.",
-            icon: IconRocket,
+            title: "Building a Culture of AI Innovation",
+            description: "Unlock the power of AI through collaboration.",
           },
           {
-            title: "Search Engine Optimization (SEO)",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-            icon: IconBrandGoogle,
-          },
-          {
-            title: "Open to new ideas and contributions",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-            icon: IconBulb
+            title: "Measuring the Value of AI",
+            description: "Ensure AI initiatives deliver tangible results.",
           },
         ]}
       />
-      <Steps />
       <FAQs
         title="Frequently Asked Questions"
         subtitle="Duis turpis dui, fringilla mattis sem nec, fringilla euismod neque. Morbi tincidunt lacus nec tortor scelerisque pulvinar."
         highlight="FAQs"
         items={[
           {
-            title: "What do I need to start?",
+            title: "What types of AI courses do you offer?",
             description:
-              "Space, the final frontier. These are the voyages of the Starship Enterprise. Its five-year mission: to explore strange new worlds. Many say exploration is part of our destiny, but it’s actually our duty to future generations.",
+              "We offer courses tailored to address key business challenges, including AI basics for beginners, role-specific training, ethical AI practices, and strategies for integrating AI into daily workflows.",
           },
           {
-            title: "How to install the Qwik + Tailwind CSS template?",
+            title: "How are your courses customized for my company's needs?", 
             description:
-              "Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows.",
+              "Our courses are designed with your goals in mind—whether you want to enhance employee productivity, foster innovation, or ensure ethical AI use, we customize training to align with your industry and workforce.",
           },
           {
-            title: "What's something that you don't understand?",
+            title: "Who should attend these courses?",
             description:
-              "A flower in my garden, a mystery in my panties. Heart attack never stopped old Big Bear. I didn't even know we were calling him Big Bear.",
+              "These courses are ideal for employees at all levels, from non-technical staff to managers and technical teams, ensuring everyone gains the skills and confidence to work effectively with AI.",
           },
           {
-            title: "What's an example of when you changed your mind?",
+            title: "How will these courses benefit my team?",
             description:
-              "Michael Knight a young loner on a crusade to champion the cause of the innocent. The helpless. The powerless in a world of criminals who operate above the law. Here he comes Here comes Speed Racer. He's a demon on wheels.",
+              "Your team will learn how to seamlessly adopt AI, enhance productivity, embrace innovation, and align with strategic goals, while reducing risks and fostering a positive workplace culture.",
           },
           {
-            title: "What is something that you would like to try again?",
+            title: "What makes your AI courses different?",
             description:
-              "A business big enough that it could be listed on the NASDAQ goes belly up. Disappears! It ceases to exist without me. No, you clearly don't know who you're talking to, so let me clue you in.",
+              "Our programs emphasize practical, role-specific training combined with actionable insights, focusing on human-AI collaboration and fostering a culture of innovation and ethical responsibility.",
           },
           {
-            title: "If you could only ask one question to each person you meet, what would that question be?",
+            title: "How long are the courses, and what formats are available?",
             description:
-              "This is not about revenge. This is about justice. A lot of things can change in twelve years, Admiral. Well, that's certainly good to know. About four years. I got tired of hearing how young I looked.",
+              "Courses vary in length, from half-day workshops to multi-session programs, and are available in-person or online to fit your company's schedule and preferences.",
           },
         ]}
       />
-      <Stats />
       <CallToAction />
     </>
   );

--- a/src/routes/menu.md
+++ b/src/routes/menu.md
@@ -1,7 +1,11 @@
 # Menu
 
-## [Services](/services)
+## Services
+
+- [Courses](/courses)
+- [Trainings](/trainings)
+- [Workshops](/workshops)
+
 ## [Case Studies](#)
 ## [About](/about)
 ## [Newsletter](https://newsletter.aiartistry.io)
-

--- a/src/routes/menu.md
+++ b/src/routes/menu.md
@@ -1,6 +1,6 @@
 # Menu
 
-## [Services](#)
+## [Services](/services)
 ## [Case Studies](#)
 ## [About](/about)
 ## [Newsletter](https://newsletter.aiartistry.io)

--- a/src/routes/services/index.tsx
+++ b/src/routes/services/index.tsx
@@ -1,0 +1,119 @@
+import { component$ } from "@builder.io/qwik";
+import type { DocumentHead } from "@builder.io/qwik-city";
+
+import Hero from "~/components/widgets/Hero_Services";
+import Features from "~/components/widgets/Features";
+import Steps from "~/components/widgets/Steps";
+import FAQs from "~/components/widgets/FAQs";
+import Stats from "~/components/widgets/Stats";
+import CallToAction from "~/components/widgets/CallToAction";
+
+import { qwikSerialized } from "~/utils/qwikSerialized";
+
+const IconBrandTailwind = qwikSerialized(() => import("../../components/icons/IconBrandTailwind"));
+const IconApps = qwikSerialized(() => import("../../components/icons/IconApps"));
+const IconRocket = qwikSerialized(() => import("../../components/icons/IconRocket"));
+const IconBrandGoogle = qwikSerialized(() => import("../../components/icons/IconBrandGoogle"));
+const IconBulb = qwikSerialized(() => import("../../components/icons/IconBulb"));
+
+import { SITE } from "~/config.mjs";
+
+export default component$(() => {
+  return (
+    <>
+      <Hero />
+      <Features
+        highlight="Courses"
+        title="What our courses cover"
+        subtitle="Master AI essentials in just one hour! This engaging, hands-on course equips your team with the skills and confidence to harness AI effectively and responsibly in the workplace."
+        items={[
+          {
+            title: "Qwik + Tailwind CSS Integration",
+            description:
+              "A seamless integration between two great frameworks that offer high productivity, performance and versatility.",
+            icon: IconBrandTailwind,
+          },
+          {
+            title: "Ready-to-use Components",
+            description:
+              "Widgets made with Tailwind CSS ready to be used in Marketing Websites, SaaS, Blogs, Personal Profiles, Small Business...",
+            icon: IconApps,
+          },
+          {
+            title: "Best Practices",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+          },
+          {
+            title: "Excellent Page Speed",
+            description:
+              "Having a good page speed impacts organic search ranking, improves user experience (UI/UX) and increase conversion rates.",
+            icon: IconRocket,
+          },
+          {
+            title: "Search Engine Optimization (SEO)",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            icon: IconBrandGoogle,
+          },
+          {
+            title: "Open to new ideas and contributions",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            icon: IconBulb
+          },
+        ]}
+      />
+      <Steps />
+      <FAQs
+        title="Frequently Asked Questions"
+        subtitle="Duis turpis dui, fringilla mattis sem nec, fringilla euismod neque. Morbi tincidunt lacus nec tortor scelerisque pulvinar."
+        highlight="FAQs"
+        items={[
+          {
+            title: "What do I need to start?",
+            description:
+              "Space, the final frontier. These are the voyages of the Starship Enterprise. Its five-year mission: to explore strange new worlds. Many say exploration is part of our destiny, but it’s actually our duty to future generations.",
+          },
+          {
+            title: "How to install the Qwik + Tailwind CSS template?",
+            description:
+              "Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows.",
+          },
+          {
+            title: "What's something that you don't understand?",
+            description:
+              "A flower in my garden, a mystery in my panties. Heart attack never stopped old Big Bear. I didn't even know we were calling him Big Bear.",
+          },
+          {
+            title: "What's an example of when you changed your mind?",
+            description:
+              "Michael Knight a young loner on a crusade to champion the cause of the innocent. The helpless. The powerless in a world of criminals who operate above the law. Here he comes Here comes Speed Racer. He's a demon on wheels.",
+          },
+          {
+            title: "What is something that you would like to try again?",
+            description:
+              "A business big enough that it could be listed on the NASDAQ goes belly up. Disappears! It ceases to exist without me. No, you clearly don't know who you're talking to, so let me clue you in.",
+          },
+          {
+            title: "If you could only ask one question to each person you meet, what would that question be?",
+            description:
+              "This is not about revenge. This is about justice. A lot of things can change in twelve years, Admiral. Well, that's certainly good to know. About four years. I got tired of hearing how young I looked.",
+          },
+        ]}
+      />
+      <Stats />
+      <CallToAction />
+    </>
+  );
+});
+
+export const head: DocumentHead = {
+  title: SITE.title,
+  meta: [
+    {
+      name: "description",
+      content: SITE.description,
+    },
+  ],
+};

--- a/src/routes/trainings/index.tsx
+++ b/src/routes/trainings/index.tsx
@@ -1,0 +1,117 @@
+import { component$ } from "@builder.io/qwik";
+import type { DocumentHead } from "@builder.io/qwik-city";
+
+import Features from "~/components/widgets/Features";
+import Steps from "~/components/widgets/Steps";
+import FAQs from "~/components/widgets/FAQs";
+import Stats from "~/components/widgets/Stats";
+import CallToAction from "~/components/widgets/CallToAction";
+
+import { qwikSerialized } from "~/utils/qwikSerialized";
+
+const IconBrandTailwind = qwikSerialized(() => import("../../components/icons/IconBrandTailwind"));
+const IconApps = qwikSerialized(() => import("../../components/icons/IconApps"));
+const IconRocket = qwikSerialized(() => import("../../components/icons/IconRocket"));
+const IconBrandGoogle = qwikSerialized(() => import("../../components/icons/IconBrandGoogle"));
+const IconBulb = qwikSerialized(() => import("../../components/icons/IconBulb"));
+
+import { SITE } from "~/config.mjs";
+
+export default component$(() => {
+  return (
+    <>
+      <Features
+        highlight="Courses"
+        title="What our courses cover"
+        subtitle="Master AI essentials in just one hour! This engaging, hands-on course equips your team with the skills and confidence to harness AI effectively and responsibly in the workplace."
+        items={[
+          {
+            title: "Qwik + Tailwind CSS Integration",
+            description:
+              "A seamless integration between two great frameworks that offer high productivity, performance and versatility.",
+            icon: IconBrandTailwind,
+          },
+          {
+            title: "Ready-to-use Components",
+            description:
+              "Widgets made with Tailwind CSS ready to be used in Marketing Websites, SaaS, Blogs, Personal Profiles, Small Business...",
+            icon: IconApps,
+          },
+          {
+            title: "Best Practices",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+          },
+          {
+            title: "Excellent Page Speed",
+            description:
+              "Having a good page speed impacts organic search ranking, improves user experience (UI/UX) and increase conversion rates.",
+            icon: IconRocket,
+          },
+          {
+            title: "Search Engine Optimization (SEO)",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            icon: IconBrandGoogle,
+          },
+          {
+            title: "Open to new ideas and contributions",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            icon: IconBulb
+          },
+        ]}
+      />
+      <Steps />
+      <FAQs
+        title="Frequently Asked Questions"
+        subtitle="Duis turpis dui, fringilla mattis sem nec, fringilla euismod neque. Morbi tincidunt lacus nec tortor scelerisque pulvinar."
+        highlight="FAQs"
+        items={[
+          {
+            title: "What do I need to start?",
+            description:
+              "Space, the final frontier. These are the voyages of the Starship Enterprise. Its five-year mission: to explore strange new worlds. Many say exploration is part of our destiny, but it’s actually our duty to future generations.",
+          },
+          {
+            title: "How to install the Qwik + Tailwind CSS template?",
+            description:
+              "Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows.",
+          },
+          {
+            title: "What's something that you don't understand?",
+            description:
+              "A flower in my garden, a mystery in my panties. Heart attack never stopped old Big Bear. I didn't even know we were calling him Big Bear.",
+          },
+          {
+            title: "What's an example of when you changed your mind?",
+            description:
+              "Michael Knight a young loner on a crusade to champion the cause of the innocent. The helpless. The powerless in a world of criminals who operate above the law. Here he comes Here comes Speed Racer. He's a demon on wheels.",
+          },
+          {
+            title: "What is something that you would like to try again?",
+            description:
+              "A business big enough that it could be listed on the NASDAQ goes belly up. Disappears! It ceases to exist without me. No, you clearly don't know who you're talking to, so let me clue you in.",
+          },
+          {
+            title: "If you could only ask one question to each person you meet, what would that question be?",
+            description:
+              "This is not about revenge. This is about justice. A lot of things can change in twelve years, Admiral. Well, that's certainly good to know. About four years. I got tired of hearing how young I looked.",
+          },
+        ]}
+      />
+      <Stats />
+      <CallToAction />
+    </>
+  );
+});
+
+export const head: DocumentHead = {
+  title: SITE.title,
+  meta: [
+    {
+      name: "description",
+      content: SITE.description,
+    },
+  ],
+};

--- a/src/routes/trainings/index.tsx
+++ b/src/routes/trainings/index.tsx
@@ -21,86 +21,77 @@ export default component$(() => {
   return (
     <>
       <Features
-        highlight="Courses"
-        title="What our courses cover"
-        subtitle="Master AI essentials in just one hour! This engaging, hands-on course equips your team with the skills and confidence to harness AI effectively and responsibly in the workplace."
+        highlight="Trainings"
+        title="Accelerating the adoption of AI"
+        subtitle="Master AI essentials in just one hour! Our engaging, hands-on trainings give your team the skills and confidence to harness AI."
         items={[
           {
-            title: "Qwik + Tailwind CSS Integration",
-            description:
-              "A seamless integration between two great frameworks that offer high productivity, performance and versatility.",
-            icon: IconBrandTailwind,
+            title: "Boost Employee AI Readiness",
+            description: "Equip your workforce with the skills and confidence to integrate AI seamlessly into their daily tasks.",
           },
           {
-            title: "Ready-to-use Components",
-            description:
-              "Widgets made with Tailwind CSS ready to be used in Marketing Websites, SaaS, Blogs, Personal Profiles, Small Business...",
-            icon: IconApps,
-          },
-          {
-            title: "Best Practices",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-          },
-          {
-            title: "Excellent Page Speed",
-            description:
-              "Having a good page speed impacts organic search ranking, improves user experience (UI/UX) and increase conversion rates.",
+            title: "Bridge the Strategy Gap", 
+            description: "Empower employees with clear guidance and practical training to align with your AI adoption goals.",
             icon: IconRocket,
           },
           {
-            title: "Search Engine Optimization (SEO)",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            title: "Foster a Culture of Innovation",
+            description: "Build a resilient, experimentation-driven workplace where AI enhances creativity and collaboration.",
+            icon: IconBulb,
+          },
+          {
+            title: "Enhance Productivity and Engagement",
+            description: "Leverage AI to automate mundane tasks, allowing employees to focus on high-value, meaningful work.",
+            icon: IconApps,
+          },
+          {
+            title: "Promote Ethical and Responsible AI Use",
+            description: "Ensure compliance, mitigate risks, and drive equitable AI practices through tailored education programs.",
             icon: IconBrandGoogle,
           },
           {
-            title: "Open to new ideas and contributions",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-            icon: IconBulb
+            title: "Gain a Competitive Edge",
+            description: "Transform your workforce into an AI-savvy team that delivers measurable results and drives business success.",
+            icon: IconRocket,
           },
         ]}
       />
-      <Steps />
       <FAQs
         title="Frequently Asked Questions"
-        subtitle="Duis turpis dui, fringilla mattis sem nec, fringilla euismod neque. Morbi tincidunt lacus nec tortor scelerisque pulvinar."
         highlight="FAQs"
         items={[
           {
-            title: "What do I need to start?",
+            title: "What types of AI training do you offer?",
             description:
-              "Space, the final frontier. These are the voyages of the Starship Enterprise. Its five-year mission: to explore strange new worlds. Many say exploration is part of our destiny, but it’s actually our duty to future generations.",
+              "We provide training on AI essentials, ethical practices, role-specific skills, and strategies for integrating AI into everyday workflows tailored to your business challenges.",
           },
           {
-            title: "How to install the Qwik + Tailwind CSS template?",
+            title: "Can the training be customized for my company's goals?",
             description:
-              "Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows.",
+              "Absolutely! We design our training to align with your industry, team needs, and objectives, whether it's boosting productivity, fostering innovation, or ensuring ethical AI adoption.",
           },
           {
-            title: "What's something that you don't understand?",
+            title: "Who should attend this training?",
             description:
-              "A flower in my garden, a mystery in my panties. Heart attack never stopped old Big Bear. I didn't even know we were calling him Big Bear.",
+              "Our training is suitable for everyone—from non-technical staff and managers to technical teams—empowering all levels to confidently leverage AI.",
           },
           {
-            title: "What's an example of when you changed your mind?",
+            title: "What are the benefits of this training for my team?",
             description:
-              "Michael Knight a young loner on a crusade to champion the cause of the innocent. The helpless. The powerless in a world of criminals who operate above the law. Here he comes Here comes Speed Racer. He's a demon on wheels.",
+              "Participants will gain practical skills to adopt AI effectively, enhance productivity, foster innovation, and align with strategic goals while mitigating risks.",
           },
           {
-            title: "What is something that you would like to try again?",
+            title: "What sets your training apart?",
             description:
-              "A business big enough that it could be listed on the NASDAQ goes belly up. Disappears! It ceases to exist without me. No, you clearly don't know who you're talking to, so let me clue you in.",
+              "Our programs combine hands-on training, actionable insights, and a focus on collaboration, innovation, and responsible AI usage to maximize value for your team.",
           },
           {
-            title: "If you could only ask one question to each person you meet, what would that question be?",
+            title: "What are the training durations and delivery options?",
             description:
-              "This is not about revenge. This is about justice. A lot of things can change in twelve years, Admiral. Well, that's certainly good to know. About four years. I got tired of hearing how young I looked.",
+              "Training ranges from half-day workshops to multi-session programs and is available both in-person and online to fit your schedule.",
           },
         ]}
       />
-      <Stats />
       <CallToAction />
     </>
   );

--- a/src/routes/workshops/index.tsx
+++ b/src/routes/workshops/index.tsx
@@ -20,87 +20,45 @@ import { SITE } from "~/config.mjs";
 export default component$(() => {
   return (
     <>
-      <Features
-        highlight="Courses"
-        title="What our courses cover"
-        subtitle="Master AI essentials in just one hour! This engaging, hands-on course equips your team with the skills and confidence to harness AI effectively and responsibly in the workplace."
-        items={[
-          {
-            title: "Qwik + Tailwind CSS Integration",
-            description:
-              "A seamless integration between two great frameworks that offer high productivity, performance and versatility.",
-            icon: IconBrandTailwind,
-          },
-          {
-            title: "Ready-to-use Components",
-            description:
-              "Widgets made with Tailwind CSS ready to be used in Marketing Websites, SaaS, Blogs, Personal Profiles, Small Business...",
-            icon: IconApps,
-          },
-          {
-            title: "Best Practices",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-          },
-          {
-            title: "Excellent Page Speed",
-            description:
-              "Having a good page speed impacts organic search ranking, improves user experience (UI/UX) and increase conversion rates.",
-            icon: IconRocket,
-          },
-          {
-            title: "Search Engine Optimization (SEO)",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-            icon: IconBrandGoogle,
-          },
-          {
-            title: "Open to new ideas and contributions",
-            description:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
-            icon: IconBulb
-          },
-        ]}
-      />
       <Steps />
+      <Stats />
       <FAQs
         title="Frequently Asked Questions"
         subtitle="Duis turpis dui, fringilla mattis sem nec, fringilla euismod neque. Morbi tincidunt lacus nec tortor scelerisque pulvinar."
         highlight="FAQs"
         items={[
           {
-            title: "What do I need to start?",
+            title: "What types of AI training do you offer?",
             description:
-              "Space, the final frontier. These are the voyages of the Starship Enterprise. Its five-year mission: to explore strange new worlds. Many say exploration is part of our destiny, but it’s actually our duty to future generations.",
+              "We provide training on AI essentials, ethical practices, role-specific skills, and strategies for integrating AI into everyday workflows tailored to your business challenges.",
           },
           {
-            title: "How to install the Qwik + Tailwind CSS template?",
+            title: "Can the training be customized for my company's goals?",
             description:
-              "Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows.",
+              "Absolutely! We design our training to align with your industry, team needs, and objectives, whether it's boosting productivity, fostering innovation, or ensuring ethical AI adoption.",
           },
           {
-            title: "What's something that you don't understand?",
+            title: "Who should attend this training?",
             description:
-              "A flower in my garden, a mystery in my panties. Heart attack never stopped old Big Bear. I didn't even know we were calling him Big Bear.",
+              "Our training is suitable for everyone—from non-technical staff and managers to technical teams—empowering all levels to confidently leverage AI.",
           },
           {
-            title: "What's an example of when you changed your mind?",
+            title: "What are the benefits of this training for my team?",
             description:
-              "Michael Knight a young loner on a crusade to champion the cause of the innocent. The helpless. The powerless in a world of criminals who operate above the law. Here he comes Here comes Speed Racer. He's a demon on wheels.",
+              "Participants will gain practical skills to adopt AI effectively, enhance productivity, foster innovation, and align with strategic goals while mitigating risks.",
           },
           {
-            title: "What is something that you would like to try again?",
+            title: "What sets your training apart?",
             description:
-              "A business big enough that it could be listed on the NASDAQ goes belly up. Disappears! It ceases to exist without me. No, you clearly don't know who you're talking to, so let me clue you in.",
+              "Our programs combine hands-on training, actionable insights, and a focus on collaboration, innovation, and responsible AI usage to maximize value for your team.",
           },
           {
-            title: "If you could only ask one question to each person you meet, what would that question be?",
+            title: "What are the training durations and delivery options?",
             description:
-              "This is not about revenge. This is about justice. A lot of things can change in twelve years, Admiral. Well, that's certainly good to know. About four years. I got tired of hearing how young I looked.",
+              "Training ranges from half-day workshops to multi-session programs and is available both in-person and online to fit your schedule.",
           },
         ]}
       />
-      <Stats />
       <CallToAction />
     </>
   );

--- a/src/routes/workshops/index.tsx
+++ b/src/routes/workshops/index.tsx
@@ -1,0 +1,117 @@
+import { component$ } from "@builder.io/qwik";
+import type { DocumentHead } from "@builder.io/qwik-city";
+
+import Features from "~/components/widgets/Features";
+import Steps from "~/components/widgets/Steps";
+import FAQs from "~/components/widgets/FAQs";
+import Stats from "~/components/widgets/Stats";
+import CallToAction from "~/components/widgets/CallToAction";
+
+import { qwikSerialized } from "~/utils/qwikSerialized";
+
+const IconBrandTailwind = qwikSerialized(() => import("../../components/icons/IconBrandTailwind"));
+const IconApps = qwikSerialized(() => import("../../components/icons/IconApps"));
+const IconRocket = qwikSerialized(() => import("../../components/icons/IconRocket"));
+const IconBrandGoogle = qwikSerialized(() => import("../../components/icons/IconBrandGoogle"));
+const IconBulb = qwikSerialized(() => import("../../components/icons/IconBulb"));
+
+import { SITE } from "~/config.mjs";
+
+export default component$(() => {
+  return (
+    <>
+      <Features
+        highlight="Courses"
+        title="What our courses cover"
+        subtitle="Master AI essentials in just one hour! This engaging, hands-on course equips your team with the skills and confidence to harness AI effectively and responsibly in the workplace."
+        items={[
+          {
+            title: "Qwik + Tailwind CSS Integration",
+            description:
+              "A seamless integration between two great frameworks that offer high productivity, performance and versatility.",
+            icon: IconBrandTailwind,
+          },
+          {
+            title: "Ready-to-use Components",
+            description:
+              "Widgets made with Tailwind CSS ready to be used in Marketing Websites, SaaS, Blogs, Personal Profiles, Small Business...",
+            icon: IconApps,
+          },
+          {
+            title: "Best Practices",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+          },
+          {
+            title: "Excellent Page Speed",
+            description:
+              "Having a good page speed impacts organic search ranking, improves user experience (UI/UX) and increase conversion rates.",
+            icon: IconRocket,
+          },
+          {
+            title: "Search Engine Optimization (SEO)",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            icon: IconBrandGoogle,
+          },
+          {
+            title: "Open to new ideas and contributions",
+            description:
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi sagittis, quam nec venenatis lobortis, mi risus tempus nulla.",
+            icon: IconBulb
+          },
+        ]}
+      />
+      <Steps />
+      <FAQs
+        title="Frequently Asked Questions"
+        subtitle="Duis turpis dui, fringilla mattis sem nec, fringilla euismod neque. Morbi tincidunt lacus nec tortor scelerisque pulvinar."
+        highlight="FAQs"
+        items={[
+          {
+            title: "What do I need to start?",
+            description:
+              "Space, the final frontier. These are the voyages of the Starship Enterprise. Its five-year mission: to explore strange new worlds. Many say exploration is part of our destiny, but it’s actually our duty to future generations.",
+          },
+          {
+            title: "How to install the Qwik + Tailwind CSS template?",
+            description:
+              "Well, the way they make shows is, they make one show. That show's called a pilot. Then they show that show to the people who make shows, and on the strength of that one show they decide if they're going to make more shows.",
+          },
+          {
+            title: "What's something that you don't understand?",
+            description:
+              "A flower in my garden, a mystery in my panties. Heart attack never stopped old Big Bear. I didn't even know we were calling him Big Bear.",
+          },
+          {
+            title: "What's an example of when you changed your mind?",
+            description:
+              "Michael Knight a young loner on a crusade to champion the cause of the innocent. The helpless. The powerless in a world of criminals who operate above the law. Here he comes Here comes Speed Racer. He's a demon on wheels.",
+          },
+          {
+            title: "What is something that you would like to try again?",
+            description:
+              "A business big enough that it could be listed on the NASDAQ goes belly up. Disappears! It ceases to exist without me. No, you clearly don't know who you're talking to, so let me clue you in.",
+          },
+          {
+            title: "If you could only ask one question to each person you meet, what would that question be?",
+            description:
+              "This is not about revenge. This is about justice. A lot of things can change in twelve years, Admiral. Well, that's certainly good to know. About four years. I got tired of hearing how young I looked.",
+          },
+        ]}
+      />
+      <Stats />
+      <CallToAction />
+    </>
+  );
+});
+
+export const head: DocumentHead = {
+  title: SITE.title,
+  meta: [
+    {
+      name: "description",
+      content: SITE.description,
+    },
+  ],
+};


### PR DESCRIPTION
This PR includes:

* Filling out the content and copy of the services pages, including:
   * Courses (/courses)
   * Workshops (/workshops)
   * Trainings (/trainings)
 * Making adjustments to "STATS" and "STEPS" components
 * Adding all of the new pages under the "Services" dropdown of top navigation

See screenshots:

<img width="1677" alt="AI Artistry Trainings page V1" src="https://github.com/user-attachments/assets/7b2edb33-64cc-4b7c-be87-0dfe5df32435">
<img width="1678" alt="AI Artistry Courses page V1" src="https://github.com/user-attachments/assets/1904beed-9bfa-4b72-8b1b-6f540c942ac2">
<img width="1677" alt="AI Artistry Workshops page V1" src="https://github.com/user-attachments/assets/b85e8085-62d4-4219-a085-6adaeacbc5f7">
