### PR TITLE
Terraform: Add output artifacts to the "Build" stage in main.tf

### DIFF
--- a/util/terraform/main.tf
+++ b/util/terraform/main.tf
@@ -365,6 +365,7 @@ resource "aws_codepipeline" "pipeline" {
       owner           = "AWS"
       provider        = "CodeBuild"
       input_artifacts = ["source_output"]
+      output_artifacts = ["build_output"]
       version         = "1"
 
       configuration = {

--- a/util/terraform/main.tf
+++ b/util/terraform/main.tf
@@ -207,12 +207,14 @@ resource "aws_iam_role_policy" "codebuild_policy" {
           "s3:GetObject"
         ]
         Resource = [
+          "arn:aws:s3:::${var.s3_bucket_name}",
           "arn:aws:s3:::${var.s3_bucket_name}/*"
         ]
       },
       {
         Effect = "Allow"
         Action = [
+          "cloudfront:ListInvalidations",
           "cloudfront:CreateInvalidation"
         ]
         Resource = [


### PR DESCRIPTION
This PR includes:

* Updating the  main.tf to add 'output_artifacts' key to Build stage (stage.action.output_artifiacts)"

Issue: Nothing is being added to the source code path.

![Screenshot 2025-01-09 at 3 26 15 PM](https://github.com/user-attachments/assets/f415ded2-7023-4497-b582-70362ba51d45)
