### PR TITLE
Terraform setup custom domain

### DIFF
--- a/util/terraform/README.md
+++ b/util/terraform/README.md
@@ -1,0 +1,41 @@
+# Terraform Infrastructure Setup
+
+This Terraform configuration manages the infrastructure for a static website hosted on AWS S3 with CloudFront distribution.
+
+## Infrastructure Components
+
+The main.tf file creates the following AWS resources:
+
+- S3 Bucket for website hosting
+- CloudFront Distribution with:
+  - Custom cache policy
+  - HTTPS redirection
+  - Custom error handling for SPA routing
+  - Brotli/Gzip compression
+  - Optional custom domain support
+- ACM Certificate for SSL/TLS (when using custom domain)
+- AWS CodePipeline for CI/CD
+- Required IAM roles and policies
+
+## Terraform State Management
+
+This project uses a child Terraform project (in the `terraform-state` directory) to create and manage the S3 bucket used for storing Terraform state files. This ensures state files are stored remotely and can be accessed by team members.
+
+## Usage
+
+To deploy the infrastructure:
+
+1. Run `terraform plan -var-file="dev.tfvars"` to preview the changes that will be made to your infrastructure. This command shows what resources will be created, modified, or deleted without actually making any changes.
+
+2. Run `terraform apply -var-file="dev.tfvars"` to create/update the infrastructure. This command will show the planned changes again and prompt for confirmation before making any actual changes.
+
+The `-var-file="dev.tfvars"` flag loads environment-specific variables from the dev.tfvars file. 
+
+Use `prod.tfvars` instead to deploy to production.
+
+### Prerequisites
+
+Before running Terraform commands, you need to create or set up your GitHub OAuth token. Export it as an environment variable:
+
+```## On Linux/MacOS, set OAuth
+export TF_VAR_github_token='your_new_token_here'```

--- a/util/terraform/main.tf
+++ b/util/terraform/main.tf
@@ -100,7 +100,7 @@ resource "aws_cloudfront_distribution" "website" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "http-only"
+      origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
@@ -121,26 +121,14 @@ resource "aws_cloudfront_distribution" "website" {
     max_ttl     = 86400
   }
 
-  # Optional: Configure custom domain
-  dynamic "viewer_certificate" {
-   for_each = var.domain_name != "" ? [1] : []
-   content {
-      acm_certificate_arn      = var.acm_certificate_arn
-      ssl_support_method       = "sni-only"
-      minimum_protocol_version = "TLSv1.2_2021"
-    }
-  }
-
-  # Default certificate if no custom domain
-  dynamic "viewer_certificate" {
-    for_each = var.domain_name == "" ? [1] : []
-    content {
-      cloudfront_default_certificate = true
-    }
+  viewer_certificate {
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
   }
 
   # Optional: Custom domain aliases
-  # aliases = var.domain_name != "" ? [var.domain_name] : []
+  aliases = var.domain_name != "" ? [var.domain_name, "www.${var.domain_name}"] : []
 
   restrictions {
     geo_restriction {


### PR DESCRIPTION
This pull request includes:

* Updating Terraform to use a custom domain on cloudfront distribution
* Creating a cert in ACM, and then using it as a variable in my tfvars files
* Improvements to cloudfront block of main.tf file (including forcing 'https')
* Troubleshooting and fixes to complete GoDaddy domain certification

Confirmed that my site was available at (but a known issue with 504 error at subpages: e.g. '/training').

JIRA: https://dave-nestoff.atlassian.net/browse/PER-95

<img width="1679" alt="AI Artistry Custom Domain Success" src="https://github.com/user-attachments/assets/327bd4fb-ef7c-49ed-80af-5a3f44d6ddaf" />
