### PR TITLE
Terraform: Update Cloudfront Distribution 'custom_origin_config' to be http-only

### DIFF
--- a/util/terraform/main.tf
+++ b/util/terraform/main.tf
@@ -100,7 +100,7 @@ resource "aws_cloudfront_distribution" "website" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }


### PR DESCRIPTION
This PR includes:

* Update 'main.tf' for cloudfront distribution to be http-only (corresponding with S3 need for HTTP)

JIRA: https://dave-nestoff.atlassian.net/browse/PER-106 (Fix 504 error when trying to access sub-pages, e.g. /training)