### PR TITLE
Update trainings page

### DIFF
--- a/src/components/widgets/Training.tsx
+++ b/src/components/widgets/Training.tsx
@@ -1,0 +1,56 @@
+import { component$ } from "@builder.io/qwik";
+import { twMerge } from "tailwind-merge";
+
+interface Item {
+  title?: string;
+  description?: string;
+  icon?: any;
+  classes?: Record<string, string>;
+}
+
+interface Props {
+  id?: string;
+  title?: any;
+  subtitle?: any;
+  highlight?: any;
+  items: Array<Item>;
+  isDark?: boolean;
+  classes?: any;
+}
+
+export default component$((props: Props) => {
+  const { id, title = "", subtitle = "", highlight = "", items = [], classes = {}, isDark = false } = props;
+
+  return (
+    <section class="relative" {...(id ? { id } : {})} id={id}>
+      <div class="absolute inset-0 pointer-events-none -z-[1]" aria-hidden="true">
+        <slot name="bg">
+          <div class={twMerge("absolute inset-0", isDark ? "bg-dark dark:bg-transparent" : "")}></div>
+        </slot>
+      </div>
+      <div
+        class={twMerge(
+          "relative mx-auto max-w-5xl px-4 md:px-6 py-4 md:py-8 lg:py-10 text-default flex flex-col md:flex-row",
+          classes?.container,
+          isDark ? "dark" : ""
+        )}
+      >
+        <div class="flex-1 p-4">
+          <h3 class={twMerge("text-2xl font-bold text-primary-600 dark:text-purple-200 ", classes?.headline)}>{title}</h3>
+          <p class="text-lg mt-2">{subtitle}</p>
+          <p class="text-lg mt-2 font-bold">{highlight}</p>
+        </div>
+        <div class="flex-1 p-4 border border-gray-200 rounded-lg">
+          <ul class="list-disc pl-5">
+            {items.map((item, index) => (
+              <li key={index} class="mb-2">
+                {item.icon && <span class="text-white bg-secondary-500 dark:bg-secondary-700 rounded-full w-10 h-10 p-2 md:w-12 md:h-12 md:p-3 mr-4 inline-block">{item.icon}</span>}
+                {item.text}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,7 +4,6 @@ import type { DocumentHead } from "@builder.io/qwik-city";
 import Hero from "~/components/widgets/Hero";
 import Features from "~/components/widgets/Features";
 import FAQs from "~/components/widgets/FAQs";
-import Stats from "~/components/widgets/Stats";
 import CallToAction from "~/components/widgets/CallToAction";
 
 import { qwikSerialized } from "~/utils/qwikSerialized";
@@ -19,7 +18,6 @@ export default component$(() => {
   return (
     <>
       <Hero />
-      <Stats />
       <Features
         title="What We Do"
         subtitle="We specialize in trainings, courses, and workshops designed to accelerate AI adoption across your organization."

--- a/src/routes/trainings/index.tsx
+++ b/src/routes/trainings/index.tsx
@@ -43,9 +43,9 @@ export default component$(() => {
           title="10X Copywriting with AI"
           subtitle="Learn proven systems to write 10X faster while maintaining quality"
           items={[
+            { text: "Scale content production 10X without sacrificing quality" },
             { text: "Speed techniques that cut drafting time by 90%" },
-            { text: "Includes ChatGPT mastery, CRAFT framework, and speed techniques" },
-            { text: "Generate 50+ headlines in seconds, not hours" },
+            { text: "Prompting techniques and systems for nailing your brand voice" },
             { text: "Generate 50+ headlines in seconds, not hours" }
           ]}
         />
@@ -54,19 +54,29 @@ export default component$(() => {
           subtitle="Transform your research capabilities with practical AI tools and frameworks"
           items={[
             { text: "Reduce research time from days to hours" },
-            { text: "Prerequisites required" },
-            { text: "Proven research prompts and data synthesis techniques" },
-            { text: "Generate 50+ headlines in seconds, not hours" }
+            { text: "Individualized research techniques with AI" },
+            { text: "Proven prompts for data synthesis and template creation" },
+            { text: "Tactics and models for validating research output" }
           ]}
         />
         <Training
           title="Enhanced Brainstorming with AI"
-          subtitle="Transform your team's ideation process."
+          subtitle="Transform your team's ideation process"
           items={[
-            { text: "Reduce research time from days to hours" },
-            { text: "Prerequisites required" },
-            { text: "Proven research prompts and data synthesis techniques" },
-            { text: "Generate 50+ headlines in seconds, not hours" }
+            { text: "Generate 3x more innovative ideas in half the time" },
+            { text: "Identify and incubate raw concepts into business-relevant ideas" },
+            { text: "Practical prompts for finding greenfield opportunities" },
+            { text: "Develop facilitation skills for collaborative brainstorming" }
+          ]}
+        />
+        <Training
+          title="Developing Your AI Champions"
+          subtitle="Turn your early adopters into AI evangelists"
+          items={[
+            { text: "Train the trainer fundamentals for AI adoption" },
+            { text: "Equip experts to help evaluate individual ROI" },
+            { text: "5 essential skills every AI champion needs" },
+            { text: "Equipping team members for practical AI tool evaluation" }
           ]}
         />
       </div>

--- a/src/routes/trainings/index.tsx
+++ b/src/routes/trainings/index.tsx
@@ -4,12 +4,11 @@ import type { DocumentHead } from "@builder.io/qwik-city";
 import Features from "~/components/widgets/Features";
 import FAQs from "~/components/widgets/FAQs";
 import CallToAction from "~/components/widgets/CallToAction";
+import Training from '~/components/widgets/Training';
 
 import { qwikSerialized } from "~/utils/qwikSerialized";
 
 const IconApps = qwikSerialized(() => import("../../components/icons/IconApps"));
-const IconRocket = qwikSerialized(() => import("../../components/icons/IconRocket"));
-const IconBrandGoogle = qwikSerialized(() => import("../../components/icons/IconBrandGoogle"));
 const IconBulb = qwikSerialized(() => import("../../components/icons/IconBulb"));
 
 import { SITE } from "~/config.mjs";
@@ -20,39 +19,57 @@ export default component$(() => {
       <Features
         highlight="Trainings"
         title="Accelerating the adoption of AI"
-        subtitle="Master AI essentials in just one hour! Our engaging, hands-on trainings give your team the skills and confidence to harness AI."
+        subtitle="Interactive, hands-on trainings give your team the skills and confidence to harness AI."
         items={[
           {
             title: "Boost Employee AI Readiness",
-            description: "Equip your workforce with the skills and confidence to integrate AI seamlessly into their daily tasks.",
+            description: "Equip your workforce with the skills and confidence to integrate AI into their daily tasks.",
           },
           {
             title: "Bridge the Strategy Gap", 
-            description: "Empower employees with clear guidance and practical training to align with your AI adoption goals.",
-            icon: IconRocket,
-          },
-          {
-            title: "Foster a Culture of Innovation",
-            description: "Build a resilient, experimentation-driven workplace where AI enhances creativity and collaboration.",
-            icon: IconBulb,
-          },
-          {
-            title: "Enhance Productivity and Engagement",
-            description: "Leverage AI to automate mundane tasks, allowing employees to focus on high-value, meaningful work.",
+            description: "Empower employees with clear guidance and practical training aligned to AI adoption goals.",
             icon: IconApps,
           },
           {
-            title: "Promote Ethical and Responsible AI Use",
-            description: "Ensure compliance, mitigate risks, and drive equitable AI practices through tailored education programs.",
-            icon: IconBrandGoogle,
-          },
-          {
-            title: "Gain a Competitive Edge",
-            description: "Transform your workforce into an AI-savvy team that delivers measurable results and drives business success.",
-            icon: IconRocket,
+            title: "Foster a Culture of Innovation",
+            description: "Build a resilient, experimentation-driven workplace where AI enhances creativity.",
+            icon: IconBulb,
           },
         ]}
       />
+      <div>
+        <h2 class="text-center text-4xl font-bold space-y-6">Our Trainings</h2>
+        <Training
+          title="10X Copywriting with AI"
+          subtitle="Learn proven systems to write 10X faster while maintaining quality"
+          items={[
+            { text: "Speed techniques that cut drafting time by 90%" },
+            { text: "Includes ChatGPT mastery, CRAFT framework, and speed techniques" },
+            { text: "Generate 50+ headlines in seconds, not hours" },
+            { text: "Generate 50+ headlines in seconds, not hours" }
+          ]}
+        />
+        <Training
+          title="Mastering AI-Powered Research"
+          subtitle="Transform your research capabilities with practical AI tools and frameworks"
+          items={[
+            { text: "Reduce research time from days to hours" },
+            { text: "Prerequisites required" },
+            { text: "Proven research prompts and data synthesis techniques" },
+            { text: "Generate 50+ headlines in seconds, not hours" }
+          ]}
+        />
+        <Training
+          title="Enhanced Brainstorming with AI"
+          subtitle="Transform your team's ideation process."
+          items={[
+            { text: "Reduce research time from days to hours" },
+            { text: "Prerequisites required" },
+            { text: "Proven research prompts and data synthesis techniques" },
+            { text: "Generate 50+ headlines in seconds, not hours" }
+          ]}
+        />
+      </div>
       <FAQs
         title="Frequently Asked Questions"
         highlight="FAQs"
@@ -63,19 +80,9 @@ export default component$(() => {
               "We provide training on AI essentials, ethical practices, role-specific skills, and strategies for integrating AI into everyday workflows tailored to your business challenges.",
           },
           {
-            title: "Can the training be customized for my company's goals?",
+            title: "Can the training be customized for my company?",
             description:
               "Absolutely! We design our training to align with your industry, team needs, and objectives, whether it's boosting productivity, fostering innovation, or ensuring ethical AI adoption.",
-          },
-          {
-            title: "Who should attend this training?",
-            description:
-              "Our training is suitable for everyone—from non-technical staff and managers to technical teams—empowering all levels to confidently leverage AI.",
-          },
-          {
-            title: "What are the benefits of this training for my team?",
-            description:
-              "Participants will gain practical skills to adopt AI effectively, enhance productivity, foster innovation, and align with strategic goals while mitigating risks.",
           },
           {
             title: "What sets your training apart?",
@@ -83,9 +90,9 @@ export default component$(() => {
               "Our programs combine hands-on training, actionable insights, and a focus on collaboration, innovation, and responsible AI usage to maximize value for your team.",
           },
           {
-            title: "What are the training durations and delivery options?",
+            title: "What are the training delivery options?",
             description:
-              "Training ranges from half-day workshops to multi-session programs and is available both in-person and online to fit your schedule.",
+              "Training is available both in-person and online to fit your schedule.",
           },
         ]}
       />


### PR DESCRIPTION
This PR includes:

* Updating the trainings page to include 4 trainings with core benefits
* Adding a 'training' component, including all design and HTML creation
* Separately, removing the <STATS> component from the home page

<img width="1289" alt="AI Artistry Website Training Page training list" src="https://github.com/user-attachments/assets/06e3794c-9b5e-4522-a4a8-48a5c8d4de33" />
