### PR TITLE
Add google analytics tag

### DIFF
--- a/src/components/common/RouterHead.tsx
+++ b/src/components/common/RouterHead.tsx
@@ -12,6 +12,15 @@ export const RouterHead = component$(() => {
     <>
       <title>{head.title}</title>
 
+      {/* Google tag (gtag.js) */}
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-J4J3PXYW80"></script>
+      <script dangerouslySetInnerHTML={`
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-J4J3PXYW80');
+      `} />
+
       <link rel="canonical" href={String(loc.url)} />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
This PR includes:

* Adding a GA4 tag for aiartistry.io to the `RouterHead` component

JIRA: https://dave-nestoff.atlassian.net/browse/PER-133