### PR TITLE
Fix expired SSL cert and bring ACM certificate management into Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,115 @@ Initially created by [onWidget](https://onwidget.com) and maintained by a commun
 ## License
 
 **Qwind** is licensed under the MIT license — see the [LICENSE](https://github.com/onwidget/qwind/blob/main/LICENSE.md) file for details.
+
+# AI Music Capabilities Quadrant – Customization Prompts & Documentation
+
+This README collects all the prompts and instructions used to update and customize the AI Music Capabilities Quadrant HTML file. Use these as a reference for reusing or adapting the same modifications on another HTML file.
+
+---
+
+## 1. Updating Plotted Capabilities
+**Prompt:**
+> Please pull me a list of all of the items plotted within my quadrant grid (e.g. "MIDI humanization"). I want the complete list of them added to a table format with the item in COLUMN A, and then the following other columns: "Creativity", "Authenticity", Category.
+
+---
+
+## 2. Axis Label Explanations
+**Prompt:**
+> Given my quadrant design and results, please write me two paragraphs explaining the axes for "Creativity" and "Authenticity". Get into detail about what these mean and what high/low signify for us.
+
+---
+
+## 3. Color Palette Customization
+**Prompt:**
+> How can I adjust the color palette to use the colors for my theme:
+> - Background Color: #3c3a37
+> - Text accent color: #ff9f05
+> - Text color: #ffffff
+> - Background accent color: #039de1
+
+---
+
+## 4. Changing Quadrant Background Color
+**Prompt:**
+> Please change the background color of my quadrant to white.
+
+---
+
+## 5. Adding/Removing Capabilities
+**Prompt:**
+> Please remove the following capabilities from both sections of this diagram:
+> * Audience analytics
+> * Revenue optimization
+
+**Prompt:**
+> Please add the following 12 items to both sections. And list out capabilities in their respective categories (e.g. "### Idea capture & transformation") in the lower section. You can ignore the term definitions.
+> -- Items to add START --
+> (List of new capabilities and categories)
+> -- Items to add END --
+
+**Prompt:**
+> Please remove all of the following items from both the top and bottom. This should be everything in the "Business and Analytics" category:
+> (List of items)
+
+---
+
+## 6. Recategorizing and Updating Data
+**Prompt:**
+> Please update my data to recategorize my capabilities as well as update some of the x and y axis values. Here's the new data:
+> -- New data START --
+> (New categories and capabilities with A/C values)
+> -- New data END --
+
+---
+
+## 7. Axis Label and Grid Adjustments
+**Prompt:**
+> Please update my grid so that it shows Creativity on the x axis (the same way it currently shows "Authenticity")
+
+**Prompt:**
+> Please adjust the CSS of my x-axis-label so that it shows at the bottom center of my quadrant container.
+
+**Prompt:**
+> The label the "Creativity" is not appearing in the quadrant currently.
+
+**Prompt:**
+> This will ensure the label is always visible just INSIDE the grid.
+
+**Prompt:**
+> Now please adjust the y-axis-label to have the same margin from the left side of the grid that Creativity has from the bottom.
+
+**Prompt:**
+> Please reduce the distance between "Authenticity" and the left wall of the grid.
+
+---
+
+## 8. Updating Specific Capabilities
+**Prompt:**
+> Please update the following capabilities in both the top and bottom section:
+> -- capabilities START --
+> (List of updated capabilities and values)
+> -- capabilities END --
+
+---
+
+## 9. Category Definitions
+**Prompt:**
+> Can you please pull me a list of all of the categories for my capabilities. Please also come up with a rock-solid definition of what each category refers to in the music making process. Each definition should be 40 words MAX.
+
+---
+
+## 10. Adding a Logo SVG
+**Prompt:**
+> Please add the following SVG to my file. It's my logo and it should be placed next to the title ("AI in Music Production").
+
+---
+
+## Usage
+- Copy and adapt these prompts as needed for your own HTML/CSS/JS music quadrant or similar data visualization projects.
+- For each section, replace the example data with your own as needed.
+- Use the prompts as instructions for an AI assistant or as a checklist for manual editing.
+
+---
+
+**Tip:** For best results, keep your data and categories organized, and always back up your HTML file before making bulk changes.

--- a/util/terraform/certificate.tf
+++ b/util/terraform/certificate.tf
@@ -1,0 +1,51 @@
+# certificate.tf
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+resource "aws_acm_certificate" "website" {
+  provider = aws.us_east_1
+  domain_name = var.domain_name
+  subject_alternative_names = [
+    "www.${var.domain_name}",
+    "*.${var.domain_name}"
+  ]
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "website" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.website.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.website.zone_id
+}
+
+resource "aws_acm_certificate_validation" "website" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.website.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+output "acm_certificate_arn" {
+  value = aws_acm_certificate_validation.website.certificate_arn
+}

--- a/util/terraform/main.tf
+++ b/util/terraform/main.tf
@@ -8,7 +8,8 @@ terraform {
   }
   
   backend "s3" {
-    # This will be configured via backend config file
+    bucket = "aiartistry-website-terraform-state"
+    key    = "aiartistry-website-terraform-state"
     region = "us-east-1"
   }
 }
@@ -87,7 +88,6 @@ resource "aws_s3_bucket_cors_configuration" "website" {
 
 # CloudFront distribution
 resource "aws_cloudfront_distribution" "website" {
-  depends_on = [aws_acm_certificate_validation.cert_validation]
   enabled = true
   is_ipv6_enabled = true
   default_root_object = "index.html"
@@ -121,10 +121,13 @@ resource "aws_cloudfront_distribution" "website" {
     max_ttl     = 86400
   }
 
-  viewer_certificate {
-    acm_certificate_arn      = var.acm_certificate_arn
-    ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2021"
+  dynamic "viewer_certificate" {
+    for_each = var.domain_name != "" ? [1] : []
+    content {
+      acm_certificate_arn      = aws_acm_certificate_validation.website.certificate_arn
+      ssl_support_method       = "sni-only"
+      minimum_protocol_version = "TLSv1.2_2021"
+    }
   }
 
   # Optional: Custom domain aliases
@@ -213,11 +216,11 @@ resource "aws_acm_certificate" "domain_certificate" {
 }
 
 # Resource for certificate validation
-resource "aws_acm_certificate_validation" "cert_validation" {
-  provider                = aws.us-east-1
-  certificate_arn         = aws_acm_certificate.domain_certificate.arn
-  validation_record_fqdns = [for record in aws_acm_certificate.domain_certificate.domain_validation_options : record.resource_record_name]
-}
+# resource "aws_acm_certificate_validation" "cert_validation" {
+#   provider                = aws.us-east-1
+#   certificate_arn         = aws_acm_certificate.domain_certificate.arn
+#   validation_record_fqdns = [for record in aws_acm_certificate.domain_certificate.domain_validation_options : record.resource_record_name]
+# }
 
 # CodeBuild IAM Role
 resource "aws_iam_role" "codebuild_role" {


### PR DESCRIPTION
This PR includes: 

1. Replacing the dead certificate with a Terraform-managed one and fixes related infra issues discovered along the way.
2. Adding certificate.tf that defines aws_acm_certificate.website, DNS validation records (aws_route53_record.cert_validation), and aws_acm_certificate_validation.website
3. Updating aws_cloudfront_distribution.website's viewer_certificate block to reference the new Terraform-managed certificate ARN instead of a static variable
4. Remove the acm_certificate_arn variable and its value from dev.tfvars
5. Removed a stray duplicate aws_acm_certificate_validation.cert_validation resource that referenced the old, dead certificate ARN
6. Fixed `backend "s3" {}` block in main.tf to explicitly declare bucket, key, and region rather than relying on external -backend-config flags, preventing a "backend configuration changed" error on future init runs
Important operational note

Additional Details:

* aiartistry.io's SSL certificate expired (notAfter: 2026-02-28), causing ERR_CERT_DATE_INVALID for all visitors. Investigation showed the certificate was never managed by Terraform — it was created manually and referenced in prod.tfvars via a hardcoded ARN. Because it was likely detached from CloudFront at some point before its renewal window, ACM marked it RenewalEligibility: INELIGIBLE, and once it expired it could not be renewed — only replaced.
* `prod.tfvars` is not currently a real, separate environment — it shares the same backend state as dev.tfvars, and dev.tfvars is what maps to the actual live site (aiartistry-website-dev-website, etc., despite the dev naming). Applying prod.tfvars against this state would rename/destroy/recreate live production infrastructure.

JIRA: https://dave-nestoff.atlassian.net/browse/PER-183